### PR TITLE
Move tornadoql handlers out into modules #51

### DIFF
--- a/maverick_api/modules/api/__init__.py
+++ b/maverick_api/modules/api/__init__.py
@@ -7,7 +7,6 @@ import tornado.ioloop
 from graphql import GraphQLField, GraphQLObjectType, GraphQLSchema
 from graphql.pyutils.event_emitter import EventEmitter
 
-
 class moduleBase(object):
     def __init__(self, loop, module):
         # Attributes

--- a/maverick_api/modules/api/maverick_authentication/__init__.py
+++ b/maverick_api/modules/api/maverick_authentication/__init__.py
@@ -15,7 +15,7 @@ from graphql import (
 from graphql.pyutils.event_emitter import EventEmitter, EventEmitterAsyncIterator
 
 from modules.api import schemaBase
-from modules.base.tornadoql.session_control import Session
+from modules.base.tornadoql.session_control import GraphQLSession
 
 user1 = dict(id="1", userName="sam", password="password1")
 user2 = dict(id="2", userName="ben", password="password2")
@@ -72,7 +72,7 @@ class AuthenticationSchema(schemaBase):
         """Authentication query handler"""
         return auth_data.get(id)
 
-    @Session.authenticated
+    @GraphQLSession.authenticated
     async def set_auth(self, root, info, **kwargs):
         """Authentication mutation handler"""
         usr = auth_data.get(kwargs["id"])

--- a/maverick_api/modules/api/maverick_status/__init__.py
+++ b/maverick_api/modules/api/maverick_status/__init__.py
@@ -23,8 +23,6 @@ from graphql.pyutils.event_emitter import EventEmitter, EventEmitterAsyncIterato
 from modules.api import moduleBase
 from modules.api import schemaBase
 
-from modules.base.tornadoql.session_control import Session
-
 # Setup monotonic clock
 CLOCK_MONOTONIC_RAW = 4
 class timespec(ctypes.Structure):

--- a/maverick_api/modules/base/tornadoql/__init__.py
+++ b/maverick_api/modules/base/tornadoql/__init__.py
@@ -1,0 +1,10 @@
+"""
+__all__ = ['GraphQLHandler', 'GraphQLSubscriptionHandler', 'GraphQLSession', 'GraphiQLHandler', 'SchemaHandler', 'TornadoQL']
+
+from .session_control import GraphQLSession
+from .graphql_handler import GraphQLHandler
+from .subscription_handler import GraphQLSubscriptionHandler
+from .dev_graphiql_handler import GraphiQLHandler
+from .schema_handler import SchemaHandler
+from .tornadoql import TornadoQL
+"""

--- a/maverick_api/modules/base/tornadoql/dev_graphiql_handler.py
+++ b/maverick_api/modules/base/tornadoql/dev_graphiql_handler.py
@@ -1,0 +1,9 @@
+import tornado.web
+
+class GraphiQLHandler(tornado.web.RequestHandler):
+    def get(self):
+        if options.development:
+            self.render(os.path.join(self.application.settings.get("static_path"), "graphiql.html"))
+        else:
+            self.set_status(403)
+        self.finish()

--- a/maverick_api/modules/base/tornadoql/graphql_handler.py
+++ b/maverick_api/modules/base/tornadoql/graphql_handler.py
@@ -8,8 +8,9 @@ from graphql.error import GraphQLError
 from graphql.error import format_error as format_graphql_error
 from graphql import graphql
 
-from .session_control import Session
+from .session_control import GraphQLSession
 
+from modules.api import api_schema
 
 def error_status(exception):
     if isinstance(exception, web.HTTPError):
@@ -60,7 +61,7 @@ class ExecutionError(Exception):
         self.message = "\n".join(self.errors)
 
 
-class GQLHandler(web.RequestHandler):
+class GraphQLHandler(web.RequestHandler):
     def set_default_headers(self):
         self.set_header("Access-Control-Allow-Origin", "*")
         self.set_header("Access-Control-Allow-Credentials", "true")
@@ -74,7 +75,7 @@ class GQLHandler(web.RequestHandler):
         self.set_status(204)
         self.finish()
 
-    @Session.ensure_active_session
+    @GraphQLSession.ensure_active_session
     @error_response
     async def post(self):
         #         print(self.current_user)
@@ -128,7 +129,8 @@ class GQLHandler(web.RequestHandler):
 
     @property
     def schema(self):
-        raise NotImplementedError("schema must be provided")
+        # raise NotImplementedError("schema must be provided")
+        return api_schema
 
     @property
     def middleware(self):

--- a/maverick_api/modules/base/tornadoql/schema_handler.py
+++ b/maverick_api/modules/base/tornadoql/schema_handler.py
@@ -1,0 +1,17 @@
+# graphql imports
+from graphql import graphql
+from graphql import get_introspection_query
+
+from modules.api import module_schema, api_schema
+
+import tornado.web
+
+class SchemaHandler(tornado.web.RequestHandler):
+    """introspection of the api schema"""
+
+    async def get(self):
+        query = get_introspection_query(descriptions=True)
+        introspection_query_result = await graphql(api_schema, query)
+        introspection_dict = introspection_query_result.data
+        self.write(json.dumps(introspection_dict, indent=4, sort_keys=True))
+        self.finish()

--- a/maverick_api/modules/base/tornadoql/session_control.py
+++ b/maverick_api/modules/base/tornadoql/session_control.py
@@ -7,7 +7,7 @@ import os
 import motor  # async access to mongo database
 
 
-class Session(object):
+class GraphQLSession(object):
     def __init__(self, session_id):
         self.session_id = session_id
         self.user_authenticated = True
@@ -109,7 +109,7 @@ class Session(object):
                 # create a new session
                 session_id = uuid4().__str__()
                 # use current_user alias as it is baked into tornado
-                self.current_user = Session(session_id)
+                self.current_user = GraphQLSession(session_id)
                 # connect to the session db
                 # db = self.opts["db_client"].session_database
                 try:
@@ -130,7 +130,7 @@ class Session(object):
             else:
                 # To save db access we assume the session document exists
                 # FIXME: lookup and load session if required
-                self.current_user = Session(session_id)
+                self.current_user = GraphQLSession(session_id)
             return await func(self, *args, **kwargs)
 
         return wrapper_active_session

--- a/maverick_api/modules/base/tornadoql/subscription_handler.py
+++ b/maverick_api/modules/base/tornadoql/subscription_handler.py
@@ -9,7 +9,9 @@ from graphql.language import parse
 import tornado.ioloop
 from urllib.parse import urlparse
 
-from .session_control import Session
+from .session_control import GraphQLSession
+
+from modules.api import api_schema
 
 GRAPHQL_WS = "graphql-ws"
 WS_PROTOCOL = GRAPHQL_WS
@@ -63,22 +65,30 @@ class SubscriptionObserver(object):
         self.send_error(self.op_id, error)
 
 
-class GQLSubscriptionHandler(websocket.WebSocketHandler):
+class GraphQLSubscriptionHandler(websocket.WebSocketHandler):
+    def initialize(self):
+        self.handler_sockets = []
+        self.handler_subscriptions = {}
+
     @property
     def schema(self):
-        raise NotImplementedError("schema must be provided")
+        # raise NotImplementedError("schema must be provided")
+        return api_schema
 
     @property
     def sockets(self):
-        raise NotImplementedError("sockets() must be implemented")
+        # raise NotImplementedError("sockets() must be implemented")
+        return self.handler_sockets
 
     @property
     def subscriptions(self):
-        raise NotImplementedError("subscriptions() must be implemented")
+        # raise NotImplementedError("subscriptions() must be implemented")
+        return self.handler_subscriptions.get(self, {})
 
     @subscriptions.setter
     def subscriptions(self, subscriptions):
-        raise NotImplementedError("subscriptions() must be implemented")
+        # raise NotImplementedError("subscriptions() must be implemented")
+        self.handler_subscriptions[self] = subscriptions
 
     def select_subprotocol(self, subprotocols):
         return WS_PROTOCOL

--- a/maverick_api/modules/base/tornadoql/tornadoql.py
+++ b/maverick_api/modules/base/tornadoql/tornadoql.py
@@ -1,0 +1,29 @@
+import os
+
+from modules.api import api_schema
+from modules.base.tornadoql.dev_graphiql_handler import GraphiQLHandler
+from modules.base.tornadoql.graphql_handler import GraphQLHandler
+from modules.base.tornadoql.subscription_handler import GraphQLSubscriptionHandler
+from modules.base.tornadoql.schema_handler import SchemaHandler
+
+import tornado.web
+from tornado.options import options
+
+class TornadoQL(tornado.web.Application):
+    def __init__(self):
+        handlers = [
+            (r"/subscriptions", GraphQLSubscriptionHandler),
+            (r"/graphql", GraphQLHandler),
+            (r"/graphiql", GraphiQLHandler),
+            (r"/schema", SchemaHandler),
+        ]
+
+        settings = dict(
+            debug = options.debug,
+            cookie_secret = options.app_secretkey,
+            static_path = os.path.join(options.basedir, "data", "static"),
+            xsrf_cookies=False,
+        )
+
+        TornadoQL.schema = api_schema
+        super(TornadoQL, self).__init__(handlers, **settings)


### PR DESCRIPTION
Separate out tornadoql classes and handlers to separate modules, to remove any specific logic from maverick_api.py